### PR TITLE
Azure DevOps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,7 @@ Scan all pipelines of an organization e.g. https://dev.azure.com/PowerShell
 pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell
 ```
 
-Scan all pipelines of an project e.g. https://dev.azure.com/PowerShell/PowerShell
+Scan all pipelines of a project e.g. https://dev.azure.com/PowerShell/PowerShell
 ```bash
 pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell --project PowerShell
 ```

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,14 @@ Scan all pipelines of a project e.g. https://dev.azure.com/PowerShell/PowerShell
 pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization powershell --project PowerShell
 ```
 
+### Authentication
+Create your PAT here: https://dev.azure.com/{yourproject}/_usersSettings/tokens
+
+> In the top right corner you can choose the scope (Global, Project etc.). 
+> Global in that case means per tenant. If you have access to multiple tentants you need to run a scan per tenant.
+> Get you username from an HTTPS git clone url from the UI.
+
+
 # ELK Integration
 
 To easily analyze the results you can [redirect the pipeleak](https://github.com/deviantony/docker-elk?tab=readme-ov-file#injecting-data) output using `nc` into Logstash.

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ It supports the following platforms:
 * GitLab
 * GitHub
 * BitBucket
+* Azure DevOps
 
 ## Getting Started
 
@@ -139,6 +140,23 @@ Scan all public repositories
 > If using `after`, the API becomes quite unreliable 👀
 ```bash
 pipeleak bb scan --token xxxxxxxxxxx --username auser --public --maxPipelines 5 --after 2025-03-01T15:00:00+00:00
+```
+
+## Azure DevOps
+
+Scan all pipelines the current user has access to
+```bash
+pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts
+```
+
+Scan all pipelines of an organization e.g. https://dev.azure.com/PowerShell
+```bash
+pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell
+```
+
+Scan all pipelines of an project e.g. https://dev.azure.com/PowerShell/PowerShell
+```bash
+pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell --project PowerShell
 ```
 
 # ELK Integration

--- a/readme.md
+++ b/readme.md
@@ -149,14 +149,14 @@ Scan all pipelines the current user has access to
 pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts
 ```
 
-Scan all pipelines of an organization e.g. https://dev.azure.com/PowerShell
+Scan all pipelines of an organization
 ```bash
-pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell
+pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization myOrganization
 ```
 
 Scan all pipelines of a project e.g. https://dev.azure.com/PowerShell/PowerShell
 ```bash
-pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization PowerShell --project PowerShell
+pipeleak ad scan --token xxxxxxxxxxx --username auser --artifacts --organization powershell --project PowerShell
 ```
 
 # ELK Integration

--- a/src/pipeleak/cmd/bitbucket/api.go
+++ b/src/pipeleak/cmd/bitbucket/api.go
@@ -23,7 +23,7 @@ func NewClient(username string, password string) BitBucketApiClient {
 			if 429 == res.StatusCode() {
 				log.Info().Int("status", res.StatusCode()).Msg("Retrying request, we are rate limited")
 			} else {
-				log.Debug().Int("status", res.StatusCode()).Msg("Retrying request, not due to rate limit")
+				log.Info().Int("status", res.StatusCode()).Msg("Retrying request, not due to rate limit")
 			}
 		},
 	)

--- a/src/pipeleak/cmd/bitbucket/scan.go
+++ b/src/pipeleak/cmd/bitbucket/scan.go
@@ -258,7 +258,12 @@ func getSteplog(client BitBucketApiClient, workspaceSlug string, repoSlug string
 		log.Error().Err(err).Msg("Failed fetching pipeline steps")
 	}
 
-	findings := scanner.DetectHits(logBytes, options.MaxScanGoRoutines, options.TruffleHogVerification)
+	findings, err := scanner.DetectHits(logBytes, options.MaxScanGoRoutines, options.TruffleHogVerification)
+	if err != nil {
+		log.Debug().Err(err).Str("stepUUid", stepUUID).Msg("Failed detecting secrets")
+		return
+	}
+
 	for _, finding := range findings {
 		log.Warn().Str("confidence", finding.Pattern.Pattern.Confidence).Str("ruleName", finding.Pattern.Pattern.Name).Str("value", finding.Text).Str("Run", "https://bitbucket.org/"+workspaceSlug+"/"+repoSlug+"/pipelines/results/"+pipelineUuid+"/steps/"+stepUUID).Msg("HIT")
 	}

--- a/src/pipeleak/cmd/bitbucket/scan.go
+++ b/src/pipeleak/cmd/bitbucket/scan.go
@@ -278,5 +278,5 @@ func getDownloadArtifact(client BitBucketApiClient, downloadUrl string, webUrl s
 }
 
 func scanStatus() *zerolog.Event {
-	return log.Info().Str("debug", "test")
+	return log.Info().Str("debug", "nothing to show ✔️")
 }

--- a/src/pipeleak/cmd/devops/api.go
+++ b/src/pipeleak/cmd/devops/api.go
@@ -1,0 +1,52 @@
+package devops
+
+import (
+	"net/url"
+	"path"
+
+	"github.com/rs/zerolog/log"
+
+	"resty.dev/v3"
+)
+
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/
+type AzureDevOpsApiClient struct {
+	Client resty.Client
+}
+
+func NewClient(username string, password string) AzureDevOpsApiClient {
+	bbClient := AzureDevOpsApiClient{Client: *resty.New().SetBasicAuth(username, password).SetRedirectPolicy(resty.FlexibleRedirectPolicy(5))}
+	bbClient.Client.AddRetryHooks(
+		func(res *resty.Response, err error) {
+			if 429 == res.StatusCode() {
+				log.Info().Int("status", res.StatusCode()).Msg("Retrying request, we are rate limited")
+			} else {
+				log.Debug().Int("status", res.StatusCode()).Msg("Retrying request, not due to rate limit")
+			}
+		},
+	)
+	return bbClient
+}
+
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.2&tabs=HTTP
+func (a AzureDevOpsApiClient) ListRepositories(organization string) ([]Repository, *resty.Response, error) {
+	reqUrl := ""
+	u, err := url.Parse("https://dev.azure.com/")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Unable to parse ListWorkspaceRepositoires url")
+	}
+	u.Path = path.Join(u.Path, organization, "_apis", "projects")
+	reqUrl = u.String()
+
+	resp := &PaginatedResponse[Repository]{}
+	res, err := a.Client.R().
+		SetQueryParam("api-version", "7.2-preview.4").
+		SetResult(resp).
+		Get(reqUrl)
+
+	if res.StatusCode() == 404 || res.StatusCode() == 401 {
+		log.Fatal().Int("status", res.StatusCode()).Str("organization", organization).Msg("Organization does not exist or you do not have access")
+	}
+
+	return resp.Value, res, err
+}

--- a/src/pipeleak/cmd/devops/api.go
+++ b/src/pipeleak/cmd/devops/api.go
@@ -3,6 +3,7 @@ package devops
 import (
 	"net/url"
 	"path"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
@@ -72,23 +73,70 @@ func (a AzureDevOpsApiClient) ListAccounts(ownerId string) ([]Account, *resty.Re
 }
 
 // https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.2&tabs=HTTP
-func (a AzureDevOpsApiClient) ListRepositories(organization string) ([]Repository, *resty.Response, error) {
+func (a AzureDevOpsApiClient) ListProjects(organization string) ([]Project, *resty.Response, error) {
 	reqUrl := ""
 	u, err := url.Parse("https://dev.azure.com/")
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to parse ListWorkspaceRepositoires url")
+		log.Fatal().Err(err).Msg("Unable to parse ListProjects url")
 	}
 	u.Path = path.Join(u.Path, organization, "_apis", "projects")
 	reqUrl = u.String()
 
-	resp := &PaginatedResponse[Repository]{}
+	resp := &PaginatedResponse[Project]{}
 	res, err := a.Client.R().
 		SetQueryParam("api-version", "7.2-preview.4").
 		SetResult(resp).
 		Get(reqUrl)
 
 	if res.StatusCode() == 404 || res.StatusCode() == 401 {
-		log.Fatal().Int("status", res.StatusCode()).Str("organization", organization).Msg("Organization does not exist or you do not have access")
+		log.Fatal().Int("status", res.StatusCode()).Str("organization", organization).Msg("Projects list does not exist or you do not have access")
+	}
+
+	return resp.Value, res, err
+}
+
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/pipelines/list?view=azure-devops-rest-7.2
+func (a AzureDevOpsApiClient) ListPipelines(accountName string, organization string) ([]Pipeline, *resty.Response, error) {
+	reqUrl := ""
+	u, err := url.Parse("https://dev.azure.com/")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Unable to parse ListPipelines url")
+	}
+	u.Path = path.Join(u.Path, accountName, organization, "_apis", "pipelines")
+	reqUrl = u.String()
+
+	resp := &PaginatedResponse[Pipeline]{}
+	res, err := a.Client.R().
+		SetQueryParam("api-version", "7.2-preview.1").
+		SetResult(resp).
+		Get(reqUrl)
+
+	if res.StatusCode() == 404 || res.StatusCode() == 401 {
+		log.Fatal().Int("status", res.StatusCode()).Str("account", accountName).Str("organization", organization).Msg("Pipelines list does not exist or you do not have access")
+	}
+
+	return resp.Value, res, err
+}
+
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/list?view=azure-devops-rest-7.2
+func (a AzureDevOpsApiClient) ListPipelineRuns(accountName string, organization string, pipelineId int) ([]PipelineRun, *resty.Response, error) {
+	reqUrl := ""
+	u, err := url.Parse("https://dev.azure.com/")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Unable to parse ListPipelineRuns url")
+	}
+	//GET https://dev.azure.com/{organization}/{project}/_apis/pipelines/{pipelineId}/runs?api-version=7.2-preview.1
+	u.Path = path.Join(u.Path, accountName, organization, "_apis", "pipelines", strconv.Itoa(pipelineId), "runs")
+	reqUrl = u.String()
+
+	resp := &PaginatedResponse[PipelineRun]{}
+	res, err := a.Client.R().
+		SetQueryParam("api-version", "7.2-preview.1").
+		SetResult(resp).
+		Get(reqUrl)
+
+	if res.StatusCode() == 404 || res.StatusCode() == 401 {
+		log.Fatal().Int("status", res.StatusCode()).Str("account", accountName).Str("organization", organization).Int("pipeline", pipelineId).Msg("Pipeline runs list does not exist or you do not have access")
 	}
 
 	return resp.Value, res, err

--- a/src/pipeleak/cmd/devops/api.go
+++ b/src/pipeleak/cmd/devops/api.go
@@ -22,7 +22,7 @@ func NewClient(username string, password string) AzureDevOpsApiClient {
 			if 429 == res.StatusCode() {
 				log.Info().Int("status", res.StatusCode()).Msg("Retrying request, we are rate limited")
 			} else {
-				log.Debug().Int("status", res.StatusCode()).Msg("Retrying request, not due to rate limit")
+				log.Info().Int("status", res.StatusCode()).Msg("Retrying request, not due to rate limit")
 			}
 		},
 	)

--- a/src/pipeleak/cmd/devops/devops.go
+++ b/src/pipeleak/cmd/devops/devops.go
@@ -1,0 +1,16 @@
+package devops
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewAzureDevOpsRootCmd() *cobra.Command {
+	dvoCmd := &cobra.Command{
+		Use:   "ad [command]",
+		Short: "Azure DevOps related commands",
+	}
+
+	dvoCmd.AddCommand(NewScanCmd())
+
+	return dvoCmd
+}

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -81,3 +81,16 @@ type PipelineRun struct {
 	ID           int       `json:"id"`
 	Name         string    `json:"name"`
 }
+
+type PaginatedLogsResponse[T any] struct {
+	Logs []T    `json:"logs"`
+	URL  string `json:"url"`
+}
+
+type RunLog struct {
+	CreatedOn     time.Time `json:"createdOn"`
+	ID            int       `json:"id"`
+	LastChangedOn time.Time `json:"lastChangedOn"`
+	LineCount     int       `json:"lineCount"`
+	URL           string    `json:"url"`
+}

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -23,7 +23,7 @@ type Account struct {
 	AccountName string `json:"accountName"`
 }
 
-type Repository struct {
+type Project struct {
 	ID             string    `json:"id"`
 	Name           string    `json:"name"`
 	URL            string    `json:"url"`
@@ -31,4 +31,53 @@ type Repository struct {
 	Revision       int       `json:"revision"`
 	Visibility     string    `json:"visibility"`
 	LastUpdateTime time.Time `json:"lastUpdateTime"`
+}
+
+type Pipeline struct {
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		Web struct {
+			Href string `json:"href"`
+		} `json:"web"`
+	} `json:"_links"`
+	URL      string `json:"url"`
+	ID       int    `json:"id"`
+	Revision int    `json:"revision"`
+	Name     string `json:"name"`
+	Folder   string `json:"folder"`
+}
+
+type PipelineRun struct {
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		Web struct {
+			Href string `json:"href"`
+		} `json:"web"`
+		PipelineWeb struct {
+			Href string `json:"href"`
+		} `json:"pipeline.web"`
+		Pipeline struct {
+			Href string `json:"href"`
+		} `json:"pipeline"`
+	} `json:"_links"`
+	TemplateParameters struct {
+	} `json:"templateParameters"`
+	Pipeline struct {
+		URL      string `json:"url"`
+		ID       int    `json:"id"`
+		Revision int    `json:"revision"`
+		Name     string `json:"name"`
+		Folder   string `json:"folder"`
+	} `json:"pipeline"`
+	State        string    `json:"state"`
+	Result       string    `json:"result"`
+	CreatedDate  time.Time `json:"createdDate"`
+	FinishedDate time.Time `json:"finishedDate"`
+	URL          string    `json:"url"`
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
 }

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -181,3 +181,20 @@ type BuildLog struct {
 	Type          string    `json:"type"`
 	URL           string    `json:"url"`
 }
+
+
+type Artifact struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Source   string `json:"source"`
+	Resource struct {
+		Type       string `json:"type"`
+		Data       string `json:"data"`
+		Properties struct {
+			Localpath    string `json:"localpath"`
+			Artifactsize string `json:"artifactsize"`
+		} `json:"properties"`
+		URL         string `json:"url"`
+		DownloadURL string `json:"downloadUrl"`
+	} `json:"resource"`
+}

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -3,8 +3,24 @@ package devops
 import "time"
 
 type PaginatedResponse[T any] struct {
-	Count             int `json:"count"`
-	Value             []T `json:"value"`
+	Count int `json:"count"`
+	Value []T `json:"value"`
+}
+
+type AuthenticatedUser struct {
+	DisplayName  string    `json:"displayName"`
+	PublicAlias  string    `json:"publicAlias"`
+	EmailAddress string    `json:"emailAddress"`
+	CoreRevision int       `json:"coreRevision"`
+	TimeStamp    time.Time `json:"timeStamp"`
+	ID           string    `json:"id"`
+	Revision     int       `json:"revision"`
+}
+
+type Account struct {
+	AccountID   string `json:"accountId"`
+	AccountURI  string `json:"accountUri"`
+	AccountName string `json:"accountName"`
 }
 
 type Repository struct {

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -33,7 +33,7 @@ type Project struct {
 	LastUpdateTime time.Time `json:"lastUpdateTime"`
 }
 
-type Pipeline struct {
+type Build struct {
 	Links struct {
 		Self struct {
 			Href string `json:"href"`
@@ -41,56 +41,143 @@ type Pipeline struct {
 		Web struct {
 			Href string `json:"href"`
 		} `json:"web"`
+		SourceVersionDisplayURI struct {
+			Href string `json:"href"`
+		} `json:"sourceVersionDisplayUri"`
+		Timeline struct {
+			Href string `json:"href"`
+		} `json:"timeline"`
+		Badge struct {
+			Href string `json:"href"`
+		} `json:"badge"`
 	} `json:"_links"`
-	URL      string `json:"url"`
-	ID       int    `json:"id"`
-	Revision int    `json:"revision"`
-	Name     string `json:"name"`
-	Folder   string `json:"folder"`
+	Properties struct {
+	} `json:"properties"`
+	Tags              []interface{} `json:"tags"`
+	ValidationResults []interface{} `json:"validationResults"`
+	Plans             []struct {
+		PlanID string `json:"planId"`
+	} `json:"plans"`
+	TriggerInfo struct {
+	} `json:"triggerInfo"`
+	ID          int       `json:"id"`
+	BuildNumber string    `json:"buildNumber"`
+	Status      string    `json:"status"`
+	Result      string    `json:"result"`
+	QueueTime   time.Time `json:"queueTime"`
+	StartTime   time.Time `json:"startTime"`
+	FinishTime  time.Time `json:"finishTime"`
+	URL         string    `json:"url"`
+	Definition  struct {
+		Drafts      []interface{} `json:"drafts"`
+		ID          int           `json:"id"`
+		Name        string        `json:"name"`
+		URL         string        `json:"url"`
+		URI         string        `json:"uri"`
+		Path        string        `json:"path"`
+		Type        string        `json:"type"`
+		QueueStatus string        `json:"queueStatus"`
+		Revision    int           `json:"revision"`
+		Project     struct {
+			ID             string    `json:"id"`
+			Name           string    `json:"name"`
+			URL            string    `json:"url"`
+			State          string    `json:"state"`
+			Revision       int       `json:"revision"`
+			Visibility     string    `json:"visibility"`
+			LastUpdateTime time.Time `json:"lastUpdateTime"`
+		} `json:"project"`
+	} `json:"definition"`
+	BuildNumberRevision int `json:"buildNumberRevision"`
+	Project             struct {
+		ID             string    `json:"id"`
+		Name           string    `json:"name"`
+		URL            string    `json:"url"`
+		State          string    `json:"state"`
+		Revision       int       `json:"revision"`
+		Visibility     string    `json:"visibility"`
+		LastUpdateTime time.Time `json:"lastUpdateTime"`
+	} `json:"project"`
+	URI           string `json:"uri"`
+	SourceBranch  string `json:"sourceBranch"`
+	SourceVersion string `json:"sourceVersion"`
+	Queue         struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+		Pool struct {
+			ID       int    `json:"id"`
+			Name     string `json:"name"`
+			IsHosted bool   `json:"isHosted"`
+		} `json:"pool"`
+	} `json:"queue"`
+	Priority     string `json:"priority"`
+	Reason       string `json:"reason"`
+	RequestedFor struct {
+		DisplayName string `json:"displayName"`
+		URL         string `json:"url"`
+		Links       struct {
+			Avatar struct {
+				Href string `json:"href"`
+			} `json:"avatar"`
+		} `json:"_links"`
+		ID         string `json:"id"`
+		UniqueName string `json:"uniqueName"`
+		ImageURL   string `json:"imageUrl"`
+		Descriptor string `json:"descriptor"`
+	} `json:"requestedFor"`
+	RequestedBy struct {
+		DisplayName string `json:"displayName"`
+		URL         string `json:"url"`
+		Links       struct {
+			Avatar struct {
+				Href string `json:"href"`
+			} `json:"avatar"`
+		} `json:"_links"`
+		ID         string `json:"id"`
+		UniqueName string `json:"uniqueName"`
+		ImageURL   string `json:"imageUrl"`
+		Descriptor string `json:"descriptor"`
+	} `json:"requestedBy"`
+	LastChangedDate time.Time `json:"lastChangedDate"`
+	LastChangedBy   struct {
+		DisplayName string `json:"displayName"`
+		URL         string `json:"url"`
+		Links       struct {
+			Avatar struct {
+				Href string `json:"href"`
+			} `json:"avatar"`
+		} `json:"_links"`
+		ID         string `json:"id"`
+		UniqueName string `json:"uniqueName"`
+		ImageURL   string `json:"imageUrl"`
+		Descriptor string `json:"descriptor"`
+	} `json:"lastChangedBy"`
+	OrchestrationPlan struct {
+		PlanID string `json:"planId"`
+	} `json:"orchestrationPlan"`
+	Logs struct {
+		ID   int    `json:"id"`
+		Type string `json:"type"`
+		URL  string `json:"url"`
+	} `json:"logs"`
+	Repository struct {
+		ID                 string      `json:"id"`
+		Type               string      `json:"type"`
+		Name               string      `json:"name"`
+		URL                string      `json:"url"`
+		Clean              interface{} `json:"clean"`
+		CheckoutSubmodules bool        `json:"checkoutSubmodules"`
+	} `json:"repository"`
+	RetainedByRelease            bool        `json:"retainedByRelease"`
+	TriggeredByBuild             interface{} `json:"triggeredByBuild"`
+	AppendCommitMessageToRunName bool        `json:"appendCommitMessageToRunName"`
 }
 
-type PipelineRun struct {
-	Links struct {
-		Self struct {
-			Href string `json:"href"`
-		} `json:"self"`
-		Web struct {
-			Href string `json:"href"`
-		} `json:"web"`
-		PipelineWeb struct {
-			Href string `json:"href"`
-		} `json:"pipeline.web"`
-		Pipeline struct {
-			Href string `json:"href"`
-		} `json:"pipeline"`
-	} `json:"_links"`
-	TemplateParameters struct {
-	} `json:"templateParameters"`
-	Pipeline struct {
-		URL      string `json:"url"`
-		ID       int    `json:"id"`
-		Revision int    `json:"revision"`
-		Name     string `json:"name"`
-		Folder   string `json:"folder"`
-	} `json:"pipeline"`
-	State        string    `json:"state"`
-	Result       string    `json:"result"`
-	CreatedDate  time.Time `json:"createdDate"`
-	FinishedDate time.Time `json:"finishedDate"`
-	URL          string    `json:"url"`
-	ID           int       `json:"id"`
-	Name         string    `json:"name"`
-}
-
-type PaginatedLogsResponse[T any] struct {
-	Logs []T    `json:"logs"`
-	URL  string `json:"url"`
-}
-
-type RunLog struct {
-	CreatedOn     time.Time `json:"createdOn"`
-	ID            int       `json:"id"`
-	LastChangedOn time.Time `json:"lastChangedOn"`
+type BuildLog struct {
 	LineCount     int       `json:"lineCount"`
+	CreatedOn     time.Time `json:"createdOn"`
+	LastChangedOn time.Time `json:"lastChangedOn"`
+	ID            int       `json:"id"`
+	Type          string    `json:"type"`
 	URL           string    `json:"url"`
 }

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -1,0 +1,18 @@
+package devops
+
+import "time"
+
+type PaginatedResponse[T any] struct {
+	Count             int `json:"count"`
+	Value             []T `json:"value"`
+}
+
+type Repository struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	URL            string    `json:"url"`
+	State          string    `json:"state"`
+	Revision       int       `json:"revision"`
+	Visibility     string    `json:"visibility"`
+	LastUpdateTime time.Time `json:"lastUpdateTime"`
+}

--- a/src/pipeleak/cmd/devops/models.go
+++ b/src/pipeleak/cmd/devops/models.go
@@ -182,7 +182,6 @@ type BuildLog struct {
 	URL           string    `json:"url"`
 }
 
-
 type Artifact struct {
 	ID       int    `json:"id"`
 	Name     string `json:"name"`

--- a/src/pipeleak/cmd/devops/scan.go
+++ b/src/pipeleak/cmd/devops/scan.go
@@ -110,6 +110,21 @@ func scanOrganization(client AzureDevOpsApiClient, organization string) {
 
 				for _, run := range runs {
 					log.Debug().Str("url", run.Links.Web.Href).Msg("Pipeline run")
+
+					logs, _, err := client.ListRunLogs(account.AccountName, project.Name, pipeline.ID, run.ID)
+					if err != nil {
+						log.Error().Err(err).Str("account", account.AccountName).Str("project", project.Name).Int("pipeline", pipeline.ID).Int("run", run.ID).Msg("Failed fetching pipeline run log")
+					}
+
+					for _, lg := range logs {
+						log.Debug().Str("url", run.Links.Web.Href).Any("sadf", lg).Msg("Pipeline run log")
+
+						logLines, _, err := client.GetLog(account.AccountName, project.Name, pipeline.ID, run.ID, lg.ID)
+						if err != nil {
+							log.Error().Err(err).Str("account", account.AccountName).Str("project", project.Name).Int("pipeline", pipeline.ID).Int("run", run.ID).Msg("Failed fetching pipeline run log")
+						}
+						log.Warn().Str("logs", string(logLines)).Any("sadf", lg).Msg("LLOG")
+					}
 				}
 			}
 		}

--- a/src/pipeleak/cmd/devops/scan.go
+++ b/src/pipeleak/cmd/devops/scan.go
@@ -1,0 +1,94 @@
+package devops
+
+import (
+	"context"
+
+	"github.com/CompassSecurity/pipeleak/helper"
+	"github.com/CompassSecurity/pipeleak/scanner"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+type DevOpsScanOptions struct {
+	Username               string
+	AccessToken            string
+	Verbose                bool
+	ConfidenceFilter       []string
+	MaxScanGoRoutines      int
+	TruffleHogVerification bool
+	MaxPipelines           int
+	Organization           string
+	//Owned                  bool
+	//Public                 bool
+	//After                  string
+	//SearchQuery            string
+	Artifacts bool
+	Context   context.Context
+	Client    AzureDevOpsApiClient
+}
+
+var options = DevOpsScanOptions{}
+
+func NewScanCmd() *cobra.Command {
+	scanCmd := &cobra.Command{
+		Use:   "scan [no options!]",
+		Short: "Scan DevOps Actions",
+		Run:   Scan,
+	}
+	scanCmd.Flags().StringVarP(&options.AccessToken, "token", "t", "", "Azure DevOps Personal Access Token - https://dev.azure.com/{yourUsername}/_usersSettings/tokens")
+	scanCmd.MarkFlagRequired("token")
+	scanCmd.Flags().StringVarP(&options.Username, "username", "u", "", "Username")
+	scanCmd.MarkFlagRequired("username")
+	scanCmd.MarkFlagsRequiredTogether("token", "username")
+
+	scanCmd.Flags().StringSliceVarP(&options.ConfidenceFilter, "confidence", "", []string{}, "Filter for confidence level, separate by comma if multiple. See readme for more info.")
+	scanCmd.PersistentFlags().IntVarP(&options.MaxScanGoRoutines, "threads", "", 4, "Nr of threads used to scan")
+	scanCmd.PersistentFlags().BoolVarP(&options.TruffleHogVerification, "truffleHogVerification", "", true, "Enable the TruffleHog credential verification, will actively test the found credentials and only report those. Disable with --truffleHogVerification=false")
+	scanCmd.PersistentFlags().IntVarP(&options.MaxPipelines, "maxPipelines", "", -1, "Max. number of pipelines to scan per repository")
+	scanCmd.PersistentFlags().BoolVarP(&options.Artifacts, "artifacts", "a", false, "Scan workflow artifacts")
+	scanCmd.Flags().StringVarP(&options.Organization, "organization", "o", "", "Organization name to scan")
+	scanCmd.MarkFlagRequired("organization")
+	//scanCmd.PersistentFlags().BoolVarP(&options.Owned, "owned", "", false, "Scan user onwed projects only")
+	//scanCmd.PersistentFlags().BoolVarP(&options.Public, "public", "p", false, "Scan all public repositories")
+	//scanCmd.PersistentFlags().StringVarP(&options.After, "after", "", "", "Filter public repos by a given date in ISO 8601 format: 2025-04-02T15:00:00+02:00 ")
+	//scanCmd.Flags().StringVarP(&options.SearchQuery, "search", "s", "", "DevOps search query")
+
+	scanCmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "v", false, "Verbose logging")
+
+	return scanCmd
+}
+
+func Scan(cmd *cobra.Command, args []string) {
+	helper.SetLogLevel(options.Verbose)
+	go helper.ShortcutListeners(scanStatus)
+
+	scanner.InitRules(options.ConfidenceFilter)
+
+	options.Context = context.Background()
+	options.Client = NewClient(options.Username, options.AccessToken)
+	scanOrganization(options.Client, options.Organization)
+	log.Info().Msg("Scan Finished, Bye Bye 🏳️‍🌈🔥")
+}
+
+// notes: https://dev.azure.com/PowerShell/PowerShell/_apis/pipelines
+func scanOrganization(client AzureDevOpsApiClient, organization string) {
+	for {
+		repos, _, err := client.ListRepositories(organization)
+		if err != nil {
+			log.Error().Err(err).Str("organization", organization).Msg("Failed fetching repositories")
+		}
+
+		for _, repo := range repos {
+			log.Debug().Str("url", getRepoWebUrl(organization, repo.Name)).Msg("Repository")
+		}
+	}
+}
+
+func getRepoWebUrl(organization string, repo string) string {
+	return "https://dev.azure.com/" + organization + "/" + repo
+}
+
+func scanStatus() *zerolog.Event {
+	return log.Info().Str("debug", "nothing to show ✔️")
+}

--- a/src/pipeleak/cmd/devops/scan.go
+++ b/src/pipeleak/cmd/devops/scan.go
@@ -111,6 +111,11 @@ func listAccounts(client AzureDevOpsApiClient, userId string) {
 		log.Fatal().Err(err).Str("userId", userId).Msg("Failed fetching accounts")
 	}
 
+	if len(accounts) == 0 {
+		log.Info().Msg("No accounts found, check your token access scope!")
+		return
+	}
+
 	for _, account := range accounts {
 		log.Debug().Str("name", account.AccountName).Msg("Scanning Account")
 		listProjects(client, account.AccountName)
@@ -188,7 +193,7 @@ func listLogs(client AzureDevOpsApiClient, organization string, project string, 
 func scanLogLines(logs []byte, buildWebUrl string) {
 	findings, err := scanner.DetectHits(logs, options.MaxScanGoRoutines, options.TruffleHogVerification)
 	if err != nil {
-		log.Debug().Err(err).Str("build", buildWebUrl).Msg("Failed detecting secrets")
+		log.Debug().Err(err).Str("build", buildWebUrl).Msg("Failed detecting secrets of a single log line")
 		return
 	}
 

--- a/src/pipeleak/cmd/devops/scan.go
+++ b/src/pipeleak/cmd/devops/scan.go
@@ -175,6 +175,7 @@ func listLogs(client AzureDevOpsApiClient, organization string, project string, 
 	}
 
 	for _, logEntry := range logs {
+		log.Trace().Str("url", logEntry.URL).Msg("Analyze log")
 		logLines, _, err := client.GetLog(organization, project, buildId, logEntry.ID)
 		if err != nil {
 			log.Error().Err(err).Str("organization", organization).Str("project", project).Int("build", buildId).Int("logId", logEntry.ID).Msg("Failed fetching build log lines")
@@ -200,6 +201,7 @@ func listArtifacts(client AzureDevOpsApiClient, organization string, project str
 		}
 
 		for _, artifact := range artifacts {
+			log.Trace().Str("name", artifact.Name).Msg("Analyze artifact")
 			analyzeArtifact(client, artifact, buildWebUrl)
 		}
 

--- a/src/pipeleak/cmd/devops/scan.go
+++ b/src/pipeleak/cmd/devops/scan.go
@@ -39,9 +39,15 @@ func NewScanCmd() *cobra.Command {
 		Run:   Scan,
 	}
 	scanCmd.Flags().StringVarP(&options.AccessToken, "token", "t", "", "Azure DevOps Personal Access Token - https://dev.azure.com/{yourUsername}/_usersSettings/tokens")
-	scanCmd.MarkFlagRequired("token")
+	err := scanCmd.MarkFlagRequired("token")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed marking token required")
+	}
 	scanCmd.Flags().StringVarP(&options.Username, "username", "u", "", "Username")
-	scanCmd.MarkFlagRequired("username")
+	err = scanCmd.MarkFlagRequired("username")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed marking username required")
+	}
 	scanCmd.MarkFlagsRequiredTogether("token", "username")
 
 	scanCmd.Flags().StringSliceVarP(&options.ConfidenceFilter, "confidence", "", []string{}, "Filter for confidence level, separate by comma if multiple. See readme for more info.")

--- a/src/pipeleak/cmd/github/scan.go
+++ b/src/pipeleak/cmd/github/scan.go
@@ -343,7 +343,12 @@ func downloadWorkflowRunLog(client *github.Client, repo *github.Repository, work
 	log.Trace().Msg("Downloading run log")
 	logs := downloadRunLogZIP(logURL.String())
 	log.Trace().Msg("Finished downloading run log")
-	findings := scanner.DetectHits(logs, options.MaxScanGoRoutines, options.TruffleHogVerification)
+	findings, err := scanner.DetectHits(logs, options.MaxScanGoRoutines, options.TruffleHogVerification)
+	if err != nil {
+		log.Debug().Err(err).Str("workflowRun", *workflowRun.HTMLURL).Msg("Failed detecting secrets")
+		return
+	}
+
 	for _, finding := range findings {
 		log.Warn().Str("confidence", finding.Pattern.Pattern.Confidence).Str("ruleName", finding.Pattern.Pattern.Name).Str("value", finding.Text).Str("workflowRun", *workflowRun.HTMLURL).Msg("HIT")
 	}

--- a/src/pipeleak/cmd/root.go
+++ b/src/pipeleak/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/CompassSecurity/pipeleak/cmd/devops"
 	"github.com/CompassSecurity/pipeleak/cmd/bitbucket"
 	"github.com/CompassSecurity/pipeleak/cmd/github"
 	"github.com/CompassSecurity/pipeleak/cmd/gitlab"
@@ -32,6 +33,7 @@ func init() {
 	rootCmd.AddCommand(github.NewGitHubRootCmd())
 	rootCmd.AddCommand(gitlab.NewGitLabRootCmd())
 	rootCmd.AddCommand(bitbucket.NewBitBucketRootCmd())
+	rootCmd.AddCommand(devops.NewAzureDevOpsRootCmd())
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogoutput, "json", "", false, "Use JSON as log output format")
 }
 

--- a/src/pipeleak/cmd/root.go
+++ b/src/pipeleak/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/CompassSecurity/pipeleak/cmd/devops"
 	"github.com/CompassSecurity/pipeleak/cmd/bitbucket"
+	"github.com/CompassSecurity/pipeleak/cmd/devops"
 	"github.com/CompassSecurity/pipeleak/cmd/github"
 	"github.com/CompassSecurity/pipeleak/cmd/gitlab"
 	"github.com/rs/zerolog"

--- a/src/pipeleak/scanner/rules.go
+++ b/src/pipeleak/scanner/rules.go
@@ -137,8 +137,6 @@ func InitRules(confidenceFilter []string) {
 func AppendPipeleakRules(rules []PatternElement) []PatternElement {
 	customRules := []PatternElement{}
 	customRules = append(customRules, PatternElement{Pattern: PatternPattern{Name: "Gitlab - Predefined Environment Variable", Regex: `(GITLAB_USER_ID|KUBECONFIG|CI_SERVER_TLS_KEY_FILE|CI_REPOSITORY_URL|CI_REGISTRY_PASSWORD|DOCKER_AUTH_CONFIG)=.*`, Confidence: "medium"}})
-	customRules = append(customRules, PatternElement{Pattern: PatternPattern{Name: "Docker Registry Auth JSON", Regex: `{[\S\s]*"auths":.*"(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})`, Confidence: "medium"}})
-
 	return slices.Concat(rules, customRules)
 }
 


### PR DESCRIPTION
- [x] Pagination https://stackoverflow.com/questions/63986932/azure-devops-rest-api-pagination-and-rate-limit
- [x] Artifacts
- [x] Logs
- [x] Organizations List?
- [x] Rate Limiter - resty should handle it automatically https://resty.dev/docs/new-features-and-enhancements/ Retry-After
- [x] Scan specific repo only - sometimes only repo is public https://dev.azure.com/PowerShell/PowerShell
- [x] Scan specific organization
- [x] Allow non-authenticated scanning for public stuff
- [x] Max nr builds to scan
- [x] revisit flags
- [ ] ~~Paginate accounts~~ unclear if this works, not documente, normal pagination does not work .... love ms
- [x] Updated token docs