### PR TITLE
Fix Windows Support

### DIFF
--- a/src/pipeleak/scanner/pipeline.go
+++ b/src/pipeleak/scanner/pipeline.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"gitlab.com/gitlab-org/api/client-go"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -87,7 +86,7 @@ func setupQueue(options *ScanOptions) {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not determine CWD")
 		}
-		relative := path.Join(cwd, queueDirectory)
+		relative := filepath.Join(cwd, queueDirectory)
 		absPath, err := filepath.Abs(relative)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed parsing absolute path")

--- a/src/pipeleak/scanner/pipeline.go
+++ b/src/pipeleak/scanner/pipeline.go
@@ -101,7 +101,7 @@ func setupQueue(options *ScanOptions) {
 	defer os.Remove(tmpfile.Name())
 	queueFileName = tmpfile.Name()
 
-	sqlUri := `file://` + queueFileName + `?_journal=WAL&_timeout=5000&_fk=true`
+	sqlUri := queueFileName + `?_journal=WAL&_timeout=5000&_fk=true`
 	queueDB, err = sql.Open("sqlite3", sqlUri)
 	log.Debug().Str("file", sqlUri).Msg("Using DB file")
 	if err != nil {


### PR DESCRIPTION
These were the changes necessary to get it to run on a Windows system.

I cross compiled it from a Linux system to produce a self-contained Windows binary with:
```
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc go build
```