### PR TITLE
ci: build and publish container image in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,9 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
         run: |
-          cp "dist/pipeleek_${VERSION}_linux_amd64/pipeleek" pipeleek_amd64
-          cp "dist/pipeleek_${VERSION}_linux_arm64/pipeleek" pipeleek_arm64
+          VERSION_NO_V="${VERSION#v}"
+          cp "dist/pipeleek_${VERSION_NO_V}_linux_amd64" pipeleek_amd64
+          cp "dist/pipeleek_${VERSION_NO_V}_linux_arm64" pipeleek_arm64
           chmod +x pipeleek_amd64 pipeleek_arm64
       - name: Build and push container image
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,8 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
         run: |
-          cp "dist/pipeleek_${VERSION}_linux_amd64" pipeleek_amd64
-          cp "dist/pipeleek_${VERSION}_linux_arm64" pipeleek_arm64
+          cp "dist/pipeleek_${VERSION}_linux_amd64/pipeleek" pipeleek_amd64
+          cp "dist/pipeleek_${VERSION}_linux_arm64/pipeleek" pipeleek_arm64
           chmod +x pipeleek_amd64 pipeleek_arm64
       - name: Build and push container image
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary

Moves the container image build and push into `release.yaml`, directly after GoReleaser completes. This eliminates the race condition that caused the previous `container.yaml` to fail with "no assets to download".

### Changes

- **`release.yaml`**: Added QEMU, Buildx, GHCR login, Docker metadata, binary preparation, and multi-arch image build+push steps, all gated to `refs/tags/v*` so snapshot/PR runs are unaffected. Added `packages: write` permission.
- **`container.yaml`**: Deleted. Its logic is now part of `release.yaml`.

### Root Cause of the Previous Failure

The old `container.yaml` triggered on the `release: published` event and downloaded binaries via `gh release download`. Two issues:
1. **Race condition**: The event fires when the release is marked published, but GoReleaser may still be uploading assets at that moment.
2. **Naming mismatch**: The download patterns used `VERSION_NO_V` (e.g. `1.0.0`) but the actual filenames from GoReleaser are without the `v` prefix too — however the real fix is the ordering guarantee.

### How ordering is now guaranteed

Container build steps run in the same job, sequentially after GoReleaser, so binaries are always present in `dist/` when the prepare step runs.