### PR TITLE
ci: build and publish container image in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,12 +60,9 @@ jobs:
             type=raw,value=latest
       - name: Prepare binaries for container image
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          VERSION: ${{ github.ref_name }}
         run: |
-          VERSION_NO_V="${VERSION#v}"
-          cp "dist/pipeleek_${VERSION_NO_V}_linux_amd64" pipeleek_amd64
-          cp "dist/pipeleek_${VERSION_NO_V}_linux_arm64" pipeleek_arm64
+          cp "$(find dist -path 'dist/pipeleek_linux_amd64*/pipeleek' -print -quit)" pipeleek_amd64
+          cp "$(find dist -path 'dist/pipeleek_linux_arm64*/pipeleek' -print -quit)" pipeleek_arm64
           chmod +x pipeleek_amd64 pipeleek_arm64
       - name: Build and push container image
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary

Moves the container image build and push into `release.yaml`, directly after GoReleaser completes, so container publishing runs in the same ordered workflow as the release binaries.

## Why

The old standalone container workflow depended on a later release event and had no hard ordering guarantee against asset publication. Running the container build in the release workflow removes that race.

## Implementation

- moves container build/push steps into `release.yaml`
- removes the standalone `container.yaml` workflow
- copies the actual GoReleaser-built Linux binaries from the local `dist/` paths before the Docker build
- keeps container publishing gated to version tags

## Verification

The binary copy logic was validated against the exact GoReleaser paths shown in the failing release run (`dist/pipeleek_linux_amd64_v1/pipeleek` and `dist/pipeleek_linux_arm64_v8.0/pipeleek`).