### PR TITLE
Extend Copilot instructions and reusable skills

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -6,7 +6,7 @@ This document defines maintainer-oriented execution modes for Copilot work in th
 
 ### When to use
 
-Use when implementing or modifying a command and you need the repository-standard command structure.
+Use when implementing or modifying an existing command and you need the repository-standard command structure.
 
 ### Inputs required
 
@@ -80,7 +80,8 @@ Use when flags, config keys, or command semantics are updated.
 
 ### When to use
 
-Use when adding a new CLI command or subcommand, including its config bindings, docs, and tests.
+Use when adding a new CLI command or subcommand.
+Apply the `command-implementation` mode as the baseline, then add the creation-specific work in this mode.
 
 ### Inputs required
 
@@ -92,15 +93,17 @@ Use when adding a new CLI command or subcommand, including its config bindings, 
 
 - New command added with Cobra wiring and consistent flag naming.
 - Command uses `config.NewCommandSetup` with bindings, required keys, and validators.
-- Tests added or updated for command behavior.
+- Unit tests and e2e tests added or updated for command behavior.
+- Each flag defined on the new command is covered by at least one useful e2e test that asserts behavior.
 - Documentation updated for flags/config keys and usage examples.
 
 ### Validation checklist
 
 1. Confirm command is registered in the correct parent command tree.
 2. Confirm config bindings, required keys, and validators are complete.
-3. Confirm tests for the new command path pass.
-4. Confirm docs and configuration references are synchronized.
+3. Confirm unit tests and e2e tests for the new command path pass.
+4. Confirm each flag defined on the new command has at least one behavior-asserting e2e test.
+5. Confirm docs and configuration references are synchronized.
 
 ## pr-review-fixes
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,154 @@
+# Pipeleek Copilot Agent Modes
+
+This document defines maintainer-oriented execution modes for Copilot work in this repository.
+
+## command-implementation
+
+### When to use
+
+Use when implementing or modifying a command and you need the repository-standard command structure.
+
+### Inputs required
+
+- Touched command file paths.
+- Flag-to-config key bindings.
+- Required key list and validator expectations.
+- Parent command registration path and expected CLI behavior.
+
+### Expected outputs
+
+- Command follows `config.NewCommandSetup` and current repository conventions.
+- Required keys validated.
+- Values read via unified config getters.
+- Parent command registration, tests, and docs are updated when applicable.
+
+### Validation checklist
+
+1. Run focused unit tests for touched command packages.
+2. Confirm command is registered in the expected parent tree.
+3. Confirm no direct `cmd.Flags().Get*` reads remain in touched execution paths.
+
+## command-coverage
+
+### When to use
+
+Use for requests that affect "all commands" under a platform.
+
+### Inputs required
+
+- Platform root path under `internal/cmd/<platform>/`.
+- Requested behavior change to apply.
+- Any explicit exclusions from maintainers.
+
+### Expected outputs
+
+- Recursive command tree discovered under `internal/cmd/<platform>/`.
+- Scan and non-scan commands updated, including nested children.
+- No in-scope command directories skipped.
+
+### Validation checklist
+
+1. Spot-check command directories under the target platform.
+2. Verify nested command groups are covered or explicitly marked not applicable.
+3. Run targeted tests for multiple affected command groups.
+
+## docs-sync
+
+### When to use
+
+Use when flags, config keys, or command semantics are updated.
+
+### Inputs required
+
+- Changed command files and affected flags.
+- Changed config keys and inheritance impact.
+- Affected docs sections and examples.
+
+### Expected outputs
+
+- docs/introduction/configuration.md updated if key usage changed.
+- User-facing guides updated where behavior or examples changed.
+- Generated config output expectations reviewed.
+
+### Validation checklist
+
+1. Verify docs examples match command flags and key names.
+2. Verify links and section references resolve.
+3. Confirm stale flag references were removed from touched docs.
+
+## new-command
+
+### When to use
+
+Use when adding a new CLI command or subcommand, including its config bindings, docs, and tests.
+
+### Inputs required
+
+- Target platform and command path under `internal/cmd/<platform>/`.
+- Required flags and config keys.
+- Behavior intent and output expectations.
+
+### Expected outputs
+
+- New command added with Cobra wiring and consistent flag naming.
+- Command uses `config.NewCommandSetup` with bindings, required keys, and validators.
+- Tests added or updated for command behavior.
+- Documentation updated for flags/config keys and usage examples.
+
+### Validation checklist
+
+1. Confirm command is registered in the correct parent command tree.
+2. Confirm config bindings, required keys, and validators are complete.
+3. Confirm tests for the new command path pass.
+4. Confirm docs and configuration references are synchronized.
+
+## pr-review-fixes
+
+### When to use
+
+Use when a pull request has review comments that require code changes and thread resolution.
+
+### Inputs required
+
+- Active PR context and changed files.
+- Review comments/threads to address.
+- Any explicit reviewer constraints or requested behavior.
+
+### Expected outputs
+
+- Review feedback converted into concrete code changes.
+- Requested behavior and edge cases addressed in code/tests.
+- Response summary maps each fix to the corresponding review thread.
+
+### Validation checklist
+
+1. Fetch and triage open review comments before editing.
+2. Apply fixes with minimal behavioral regression risk.
+3. Run focused tests for touched areas.
+4. Confirm each addressed thread has a clear resolution note.
+
+## pr-actions-debug-fixes
+
+### When to use
+
+Use when PR status checks fail and maintainers need local reproduction, diagnosis, and fixes.
+
+### Inputs required
+
+- Failing workflow/check names and failure logs.
+- PR branch diff context.
+- Local commands needed to reproduce failing jobs.
+
+### Expected outputs
+
+- Root cause identified for each failing check.
+- Local reproduction command(s) documented.
+- Minimal fix set applied and validated locally.
+- Follow-up risk or non-reproducible gaps explicitly noted.
+
+### Validation checklist
+
+1. Extract failing checks and logs before patching.
+2. Reproduce failure locally with the closest equivalent command.
+3. Apply fix and rerun relevant local validation.
+4. Report what passed, what remains unverified, and why.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -130,7 +130,7 @@ Use when a pull request has review comments that require code changes and thread
 3. Run focused tests for touched areas.
 4. Confirm each addressed thread has a clear resolution note.
 
-## pr-actions-debug-fixes
+## pr-actions-failures-debug
 
 ### When to use
 

--- a/.github/SKILLS/command-coverage.md
+++ b/.github/SKILLS/command-coverage.md
@@ -1,0 +1,36 @@
+# Skill: Recursive Platform Command Coverage
+
+## When to use
+
+Use this skill when a request targets all commands for a platform or a broad platform-wide behavior.
+
+## Inputs required
+
+- Platform root under `internal/cmd/<platform>/`.
+- Change criteria (what must be updated across commands).
+- Any exclusions explicitly requested by maintainers.
+
+## Procedure
+
+1. Enumerate command files recursively under the platform directory.
+2. Group commands by command tree (for example: scan, renovate/*, runners/*).
+3. Identify all run entrypoints impacted by the requested change.
+4. Apply updates consistently across scan and non-scan commands.
+5. Verify nested command groups were not skipped.
+
+## Expected outputs
+
+1. Full recursive platform scope is covered unless exclusions are explicitly provided.
+2. Scan and non-scan command trees receive the requested update consistently.
+3. Coverage is reported by command groups in the implementation summary.
+
+## Acceptance checklist
+
+- All in-scope command groups are touched or explicitly marked not applicable.
+- No partial rollout to only scan commands when broader scope was requested.
+- Follow-up tests cover more than one command group when possible.
+
+## Non-goals
+
+1. Do not assume exclusions without explicit maintainer input.
+2. Do not stop at top-level command files if nested groups exist.

--- a/.github/SKILLS/command-implementation.md
+++ b/.github/SKILLS/command-implementation.md
@@ -1,0 +1,47 @@
+# Skill: Command Implementation Guidelines
+
+## When to use
+
+Use this skill when implementing or modifying a command in Pipeleek and you need to follow the repository-standard command shape.
+
+Core rule: treat `config.NewCommandSetup` and `WithFlagBindings` as a paired pattern. Do not use one without the other for consumed flags.
+
+## Inputs required
+
+- Target command file path under `internal/cmd/<platform>/`.
+- Parent command registration path.
+- Required flags and mapped config keys.
+- Expected behavior, validation needs, and test scope.
+
+## Procedure
+
+1. Place command logic under the appropriate `internal/cmd/<platform>/` path.
+2. Register the command under the correct parent command.
+3. Use `config.NewCommandSetup(cmd)` for bindings and validation.
+4. Map every consumed flag with `WithFlagBindings`.
+5. Use `RequireKeys` for mandatory values.
+6. Add validators for URL, token, thread count, or command-specific constraints as needed.
+7. Read values with config getters instead of direct flag access.
+8. Add or update focused tests for the touched command path.
+9. Update docs when flags, keys, or user-visible command behavior changes.
+
+## Expected outputs
+
+1. Command structure matches repository conventions.
+2. Config loading and validation follow the current standard.
+3. Tests cover the command path that changed.
+4. Docs stay aligned with command flags and config keys.
+
+## Acceptance checklist
+
+- Command is registered in the correct parent tree.
+- No `cmd.Flags().Get*` reads remain in command execution logic.
+- Required keys and validators are defined where needed.
+- Focused tests for touched command packages pass.
+- `docs/introduction/configuration.md` is updated when key or flag semantics change.
+
+## Non-goals
+
+1. Do not introduce legacy config binding patterns.
+2. Do not leave parent command registration incomplete.
+3. Do not skip tests or docs for user-visible command changes.

--- a/.github/SKILLS/docs-sync.md
+++ b/.github/SKILLS/docs-sync.md
@@ -1,0 +1,35 @@
+# Skill: Docs and Config Synchronization
+
+## When to use
+
+Use this skill when adding/changing flags, config keys, or command behavior that affects user docs.
+
+## Inputs required
+
+- Changed command files.
+- Changed flags and key names.
+- Affected user-facing docs sections.
+
+## Procedure
+
+1. Update docs/introduction/configuration.md for new or changed config keys.
+2. Verify examples use current flags and key names.
+3. Check related guides for stale command invocations.
+4. Confirm command help output and docs examples are aligned.
+
+## Expected outputs
+
+1. Configuration docs reflect the current key model and inheritance behavior.
+2. Guides and examples use current command syntax.
+3. Stale flag or key references are removed from touched docs.
+
+## Acceptance checklist
+
+- Configuration docs match current key naming and inheritance behavior.
+- Guides reflect current command syntax.
+- No stale flags remain in updated sections.
+
+## Non-goals
+
+1. Do not rewrite unrelated documentation sections.
+2. Do not leave config or guide examples in a mixed old/new state.

--- a/.github/SKILLS/new-command.md
+++ b/.github/SKILLS/new-command.md
@@ -4,6 +4,8 @@
 
 Use this skill when implementing a new command or subcommand in the Pipeleek CLI.
 
+This skill builds on `.github/SKILLS/command-implementation.md` and adds the extra requirements that are specific to creating a brand new command.
+
 ## Inputs required
 
 - Target command path under `internal/cmd/<platform>/`.
@@ -11,31 +13,35 @@ Use this skill when implementing a new command or subcommand in the Pipeleek CLI
 - Required flags and mapped config keys.
 - Validation requirements and test scope.
 
+## Relationship to command-implementation
+
+Apply `.github/SKILLS/command-implementation.md` as the baseline for command structure, config binding, validators, and docs sync.
+Use this skill for the additional creation-specific work below.
+
 ## Procedure
 
 1. Add the command file in the appropriate `internal/cmd/<platform>/` directory.
 2. Register the new command under the correct parent command.
-3. Use `config.NewCommandSetup(cmd)` for bindings and validation.
-4. Map all consumed flags via `WithFlagBindings`.
-5. Enforce mandatory keys with `RequireKeys`.
-6. Add validators for URL/token and command-specific constraints.
-7. Read values from config getters instead of direct flag access.
-8. Add or update tests for the command path.
-9. Update docs and config guidance when flags/keys are added.
+3. Add unit tests for the command path.
+4. Add e2e tests for the command path.
+5. Ensure each flag defined on the new command has at least one useful e2e test that asserts behavior.
+6. Update docs and config guidance when flags/keys are added.
 
 ## Expected outputs
 
 1. New command is accessible via the intended command path.
-2. Config loading follows repository standards.
-3. Tests cover the new command behavior.
-4. User-facing docs reflect the new command syntax and config keys.
+2. Base command implementation follows repository standards.
+3. Unit tests and e2e tests cover the new command behavior.
+4. Each command-defined flag is exercised by at least one behavior-asserting e2e test.
+5. User-facing docs reflect the new command syntax and config keys.
 
 ## Acceptance checklist
 
 - Command is discoverable in help output under the expected parent.
-- No `cmd.Flags().Get*` reads remain in command execution logic.
-- Required keys and validators are defined and enforced.
-- Focused tests for touched command packages pass.
+- `command-implementation` requirements are satisfied.
+- Unit tests for the touched command path pass.
+- E2E tests for the touched command path pass.
+- Each flag defined on the new command has at least one useful e2e test that asserts behavior.
 - `docs/introduction/configuration.md` is updated when key/flag semantics change.
 
 ## Non-goals

--- a/.github/SKILLS/new-command.md
+++ b/.github/SKILLS/new-command.md
@@ -1,0 +1,45 @@
+# Skill: Creating a New Command
+
+## When to use
+
+Use this skill when implementing a new command or subcommand in the Pipeleek CLI.
+
+## Inputs required
+
+- Target command path under `internal/cmd/<platform>/`.
+- Command name, purpose, and expected output.
+- Required flags and mapped config keys.
+- Validation requirements and test scope.
+
+## Procedure
+
+1. Add the command file in the appropriate `internal/cmd/<platform>/` directory.
+2. Register the new command under the correct parent command.
+3. Use `config.NewCommandSetup(cmd)` for bindings and validation.
+4. Map all consumed flags via `WithFlagBindings`.
+5. Enforce mandatory keys with `RequireKeys`.
+6. Add validators for URL/token and command-specific constraints.
+7. Read values from config getters instead of direct flag access.
+8. Add or update tests for the command path.
+9. Update docs and config guidance when flags/keys are added.
+
+## Expected outputs
+
+1. New command is accessible via the intended command path.
+2. Config loading follows repository standards.
+3. Tests cover the new command behavior.
+4. User-facing docs reflect the new command syntax and config keys.
+
+## Acceptance checklist
+
+- Command is discoverable in help output under the expected parent.
+- No `cmd.Flags().Get*` reads remain in command execution logic.
+- Required keys and validators are defined and enforced.
+- Focused tests for touched command packages pass.
+- `docs/introduction/configuration.md` is updated when key/flag semantics change.
+
+## Non-goals
+
+1. Do not mix legacy config binding patterns in the new command.
+2. Do not skip command registration in parent command trees.
+3. Do not leave docs or tests unaddressed for user-visible command additions.

--- a/.github/SKILLS/pr-actions-failures-debug.md
+++ b/.github/SKILLS/pr-actions-failures-debug.md
@@ -1,0 +1,41 @@
+# Skill: Debug PR Actions Failures and Apply Fixes Locally
+
+## When to use
+
+Use this skill when GitHub Actions checks fail on a PR and maintainers need local diagnosis and fixes.
+
+## Inputs required
+
+- Failing check names and job/workflow logs.
+- PR diff context and touched files.
+- Local equivalents of CI commands (test, lint, build, docs).
+
+## Procedure
+
+1. Collect failing checks and extract primary error messages.
+2. Identify likely failure class: test failure, lint failure, build failure, docs/generation drift, or environment mismatch.
+3. Reproduce each failure locally using closest equivalent command.
+4. Apply minimal fixes to remove root cause.
+5. Rerun relevant local checks after each fix.
+6. Record which failures were reproduced, fixed, and verified.
+7. If not reproducible, document likely causes and confidence level.
+
+## Expected outputs
+
+1. Root cause identified for each failing check where possible.
+2. Minimal patch set addresses failing checks.
+3. Local validation commands and outcomes are documented.
+4. Remaining risk is called out for non-reproducible failures.
+
+## Acceptance checklist
+
+- Failing checks/log evidence reviewed before code changes.
+- At least one local reproduction command attempted per failing class.
+- Post-fix local checks pass for impacted areas.
+- Final summary includes fixed items and unresolved risks.
+
+## Non-goals
+
+1. Do not guess fixes without correlating to failure logs.
+2. Do not ignore non-reproducible failures; document them explicitly.
+3. Do not perform unrelated cleanups while stabilizing failing checks.

--- a/.github/SKILLS/pr-review-fixes.md
+++ b/.github/SKILLS/pr-review-fixes.md
@@ -1,0 +1,41 @@
+# Skill: Address PR Review Comments and Apply Fixes
+
+## When to use
+
+Use this skill when a PR has open review comments requiring code, tests, or documentation updates.
+
+## Inputs required
+
+- Active PR details and changed files.
+- Open review threads/comments and reviewer expectations.
+- Any scope limits or non-goals provided by maintainers.
+
+## Procedure
+
+1. Fetch active PR review comments and group by concern.
+2. Classify comments into: correctness bug, regression risk, test gap, docs gap, or style.
+3. Prioritize correctness and regression risks first.
+4. Apply minimal, targeted fixes for each accepted review concern.
+5. Add tests when comments imply missing coverage or edge cases.
+6. Update docs when behavior/flags/config semantics changed.
+7. Prepare a per-thread resolution summary mapping comment to code change and validation.
+
+## Expected outputs
+
+1. Open review concerns are translated into concrete, traceable fixes.
+2. High-severity concerns are addressed first.
+3. Validation evidence is available for each meaningful fix.
+4. Unresolved or deferred comments are explicitly documented with reason.
+
+## Acceptance checklist
+
+- Every open review comment is triaged (fixed, deferred, or rejected with rationale).
+- Fixes are scoped to requested concerns and avoid unrelated refactors.
+- Focused tests pass for touched areas.
+- Resolution summary maps comment -> fix -> validation command(s).
+
+## Non-goals
+
+1. Do not resolve threads without applying or justifying the requested change.
+2. Do not introduce broad style-only refactors while addressing review comments.
+3. Do not skip test updates when reviewer feedback indicates coverage gaps.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -198,6 +198,8 @@ make serve-docs  # Installs dependencies if needed, generates and serves docs
 
 - Commands follow the Cobra pattern with `NewXCommand()` functions
 - Each command should have a corresponding test file
+- New commands must include unit tests and e2e tests.
+- Each flag defined on a new command must have at least one useful e2e test that asserts behavior.
 - Commands are organized by platform (gitlab, github, bitbucket, devops, gitea)
 - Use consistent flag naming across commands
 - **When adding or modifying command flags**: Update `docs/introduction/configuration.md` and ensure `pipeleek config gen` output remains accurate

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,18 @@
 # GitHub Copilot Instructions for Pipeleek
 
+## Maintainer Quick Index
+
+- Canonical policy and constraints: this file
+- Maintainer quick-start router: `.instructions.md`
+- Agent mode definitions: `.github/AGENTS.md`
+- Reusable task skills:
+    - `.github/SKILLS/command-implementation.md`
+    - `.github/SKILLS/command-coverage.md`
+    - `.github/SKILLS/docs-sync.md`
+    - `.github/SKILLS/new-command.md`
+    - `.github/SKILLS/pr-review-fixes.md`
+    - `.github/SKILLS/pr-actions-failures-debug.md`
+
 ## Project Overview
 
 Pipeleek is a CLI tool designed to scan CI/CD logs and artifacts for secrets across multiple platforms including GitLab, GitHub, BitBucket, Azure DevOps, and Gitea. The tool uses TruffleHog for secret detection and provides additional helper commands for exploitation workflows.
@@ -213,8 +226,8 @@ func CommandRun(cmd *cobra.Command, args []string) {
 }
 ```
 
-**Migration policy (mandatory):**
-- When modifying an existing command, migrate that touched command to `config.NewCommandSetup`.
+**Implementation policy (mandatory):**
+- Use `config.NewCommandSetup` with complete `WithFlagBindings` coverage for consumed flags.
 - Do not leave mixed setup styles in the same command implementation.
 - Use `config.NewCommandSetup` for command binding and validation.
 
@@ -235,12 +248,83 @@ func CommandRun(cmd *cobra.Command, args []string) {
 2. Identify every command Run entrypoint impacted by the request.
 3. Apply updates across all applicable child commands (scan + non-scan + nested).
 4. Verify no command directory in scope was skipped.
-5. Confirm touched commands follow `config.NewCommandSetup` migration policy.
+5. Confirm touched commands follow the `config.NewCommandSetup` implementation policy.
 
 **DO NOT:**
 - Read flags directly with `cmd.Flags().GetString()` - always use config system
 - Use legacy binder APIs removed from `pkg/config`
 - Skip required key validation for mandatory config values
+
+## Copilot Maintainer Workflow (MANDATORY)
+
+Before implementing broad or risky changes:
+
+1. State the exact scope (single command, command tree, or platform-wide).
+2. Identify files to update and validate command-tree coverage recursively when scope is broad.
+3. Define acceptance criteria (behavior, config keys, docs updates, and tests).
+
+Task intake template (use this structure in the first implementation update):
+
+1. Scope: single command, command tree, or platform-wide.
+2. In-scope files: explicit paths to be changed.
+3. Out-of-scope files: explicit exclusions.
+4. Acceptance criteria: behavior parity/change intent, docs sync, and test targets.
+
+During implementation:
+
+1. Preserve behavior unless the user requested behavior changes.
+2. Ensure touched command files use `config.NewCommandSetup` with complete `WithFlagBindings` mappings.
+3. Keep config key naming aligned with `<platform>.<key>`, `<platform>.<subcommand>.<key>`, and `common.<key>`.
+
+Before completion:
+
+1. Run focused tests for touched packages first, then broader checks as needed.
+2. If flags/keys changed, update `docs/introduction/configuration.md` and verify `pipeleek config gen` expectations.
+3. Report covered command groups and any explicit non-applicable areas.
+
+Completion checklist (must be satisfied before finalizing):
+
+1. Scope coverage reported with concrete command groups.
+2. Behavior impact stated (preserved or changed by request).
+3. Validation commands listed with outcomes.
+4. Docs sync status stated for configuration/flag changes.
+
+## Debugging Playbook for Copilot Changes
+
+When changes fail tests or behave unexpectedly:
+
+1. Reproduce with the smallest failing test target.
+2. Check config binding chain first (flag bindings, required keys, validators, and getter usage).
+3. Verify command-tree completeness for platform-wide requests to avoid partial updates.
+4. Validate user-facing examples in docs against current command syntax.
+5. Escalate only after recording what was tested and what remained inconclusive.
+
+Common failure modes and first checks:
+
+1. Missing required key at runtime:
+    - Check `RequireKeys` bindings and key naming alignment.
+2. Flag appears ignored:
+    - Check `WithFlagBindings` mapping for that flag and key.
+3. Platform-wide request partially applied:
+    - Re-run recursive command-tree enumeration under `internal/cmd/<platform>/`.
+4. Docs and command syntax mismatch:
+    - Compare changed command flags with `docs/introduction/configuration.md` and guide examples.
+
+## Security and Data Handling for Copilot Sessions
+
+1. Never log raw secrets or tokens in examples beyond redacted placeholders.
+2. Keep command examples safe for copy/paste by using redacted values (`[redacted]`).
+3. Avoid introducing docs guidance that encourages disabling verification in production workflows.
+4. Preserve and follow existing security policies in `SECURITY.md` and repository workflows.
+
+## Maintenance Cadence
+
+Update Copilot docs when one of the following changes occurs:
+
+1. Command configuration APIs in `pkg/config` change.
+2. Platform command tree structure changes.
+3. Flag or config key semantics change.
+4. Test strategy or CI validation gates change.
 
 ### Package Organization
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -229,9 +229,7 @@ func CommandRun(cmd *cobra.Command, args []string) {
 ```
 
 **Implementation policy (mandatory):**
-- Use `config.NewCommandSetup` with complete `WithFlagBindings` coverage for consumed flags.
-- Do not leave mixed setup styles in the same command implementation.
-- Use `config.NewCommandSetup` for command binding and validation.
+- For every new command, and whenever modifying an existing command, use `config.NewCommandSetup` for command binding and validation with complete `WithFlagBindings` coverage for all consumed flags; do not leave or introduce legacy or mixed setup styles in the touched command.
 
 **Key naming convention:**
 - Platform settings: `<platform>.<key>` (e.g., `github.url`, `gitlab.token`)

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,0 +1,39 @@
+# Pipeleek Copilot Maintainer Quick Start
+
+Use this file as a routing layer, not as policy source.
+
+## Intended Use
+
+Use this file to quickly route to the correct maintainer reference for the task.
+Do not duplicate policy content here.
+
+## Authoritative Policy
+
+- Primary instructions: .github/copilot-instructions.md
+
+## Maintainer Workflows
+
+- Agent modes: .github/AGENTS.md
+- Reusable skills:
+  - .github/SKILLS/command-implementation.md
+  - .github/SKILLS/command-coverage.md
+  - .github/SKILLS/docs-sync.md
+  - .github/SKILLS/new-command.md
+  - .github/SKILLS/pr-review-fixes.md
+  - .github/SKILLS/pr-actions-failures-debug.md
+
+## High-Value Reminders
+
+1. When touching a command, use `config.NewCommandSetup` with complete `WithFlagBindings` coverage.
+2. For platform-wide changes, enumerate command trees recursively under `internal/cmd/<platform>/`.
+3. If command flags or config keys change, sync docs and verify `pipeleek config gen` expectations.
+4. Start validation with targeted tests, then run broader checks if needed.
+
+## Task Routing
+
+1. Command implementation guidance: `.github/SKILLS/command-implementation.md`
+2. Platform-wide updates: `.github/SKILLS/command-coverage.md`
+3. Docs/config sync tasks: `.github/SKILLS/docs-sync.md`
+4. New command implementation: `.github/SKILLS/new-command.md`
+5. PR review comments to fixes: `.github/SKILLS/pr-review-fixes.md`
+6. PR actions failures debug and fix: `.github/SKILLS/pr-actions-failures-debug.md`

--- a/.instructions.md
+++ b/.instructions.md
@@ -34,6 +34,6 @@ Do not duplicate policy content here.
 1. Command implementation guidance: `.github/SKILLS/command-implementation.md`
 2. Platform-wide updates: `.github/SKILLS/command-coverage.md`
 3. Docs/config sync tasks: `.github/SKILLS/docs-sync.md`
-4. New command implementation: `.github/SKILLS/new-command.md`
+4. New command implementation: `.github/SKILLS/new-command.md` (use with `command-implementation` as the baseline)
 5. PR review comments to fixes: `.github/SKILLS/pr-review-fixes.md`
 6. PR actions failures debug and fix: `.github/SKILLS/pr-actions-failures-debug.md`


### PR DESCRIPTION
## Summary
Add a structured Copilot customization surface for repository work by expanding the core instructions and introducing reusable agent/skill documentation.

## Changes
- extend `.github/copilot-instructions.md` with a maintainer quick index, command implementation policy, command coverage guidance, debugging playbooks, and maintenance rules
- add `.instructions.md` as a short routing layer for Copilot task selection
- add `.github/AGENTS.md` with documented modes for command implementation, new commands, docs sync, PR review fixes, and CI failure debugging
- add reusable skill docs for command implementation, command coverage, docs sync, new command creation, PR review fixes, and PR actions failure debugging
- clarify that `config.NewCommandSetup` and `WithFlagBindings` are a paired implementation pattern
- require new commands to include unit tests, e2e tests, and behavior-asserting e2e coverage for each command-defined flag

## Notes
- documentation-only change
- no runtime code paths changed

## Validation
- verified working tree was clean before PR creation
- checked changed-file scope with `git diff --stat origin/main...HEAD`
- ran diagnostics on the touched documentation files
