### PR TITLE
fix(config): keep config set log format consistent without --json

### DIFF
--- a/internal/cmd/configcmd/set/set.go
+++ b/internal/cmd/configcmd/set/set.go
@@ -74,8 +74,7 @@ pipeleek config set gitlab.runners '{exploit: {tags: [docker]}}'`,
 				return common.LogAndWrapError("set", "write config file", err)
 			}
 
-			logger := log.Output(cmd.OutOrStdout())
-			logger.Info().Msgf("Configuration updated: %s = %v (written to %s)", key, parsedValue, writePath)
+			log.Info().Str("key", key).Interface("value", parsedValue).Str("write_path", writePath).Msg("Configuration updated")
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary
- fix `config set` success logging to use the global logger pipeline
- prevent mixed output formats when `--json` is not enabled

## Bug
`pipeleek config set` emitted a JSON log line for the success message even when global logging was configured for console output (for example with `--log-level debug` and no `--json`).

## Root Cause
The command used `log.Output(cmd.OutOrStdout())` for the success message, which bypassed the configured global logger formatting.

## Fix
Use `log.Info()` directly so the command follows the same global formatting mode as the rest of the command output.

## Validation
- manually reproduced before/after behavior with:
  - `go run ./cmd/pipeleek --config <tmpfile> --log-level debug config set common.threads 8`
- confirmed output is now consistently human-readable when `--json` is not set
